### PR TITLE
chore: modernize code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,75 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+  schedule:
+    - cron: "30 14 * * 4"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+          config: |
+            paths-ignore:
+              - 'test/*.js'
+              - '**/*.test.js'
+              - '**/*.spec.js'
+              - '**/*.test.ts'
+              - '**/*.spec.ts'
+              - '**/*.test.tsx'
+              - '**/*.spec.tsx'
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x, 18.x, 20.x, 22.x]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Test
+        run: npm test

--- a/lib/Agents.js
+++ b/lib/Agents.js
@@ -21,6 +21,7 @@
 
 // Modifications made by Brian White to work with socksv5
 
+'use strict';
 var socks = require('../index');
 
 var net = require('net');

--- a/lib/auth/None.js
+++ b/lib/auth/None.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function NoneAuthHandlers() {
   return {
     METHOD: 0x00,

--- a/lib/auth/UserPassword.js
+++ b/lib/auth/UserPassword.js
@@ -1,3 +1,4 @@
+'use strict';
 var STATE_VERSION = 0,
     // server
     STATE_ULEN = 1,

--- a/lib/auth/UserPassword.js
+++ b/lib/auth/UserPassword.js
@@ -8,8 +8,8 @@ var STATE_VERSION = 0,
     STATE_STATUS = 5;
 
     // server
-var BUF_SUCCESS = new Buffer([0x01, 0x00]),
-    BUF_FAILURE = new Buffer([0x01, 0x01]);
+var BUF_SUCCESS = Buffer.from([0x01, 0x00]),
+    BUF_FAILURE = Buffer.from([0x01, 0x01]);
 
 module.exports = function UserPasswordAuthHandlers() {
   var authcb,
@@ -75,7 +75,7 @@ module.exports = function UserPasswordAuthHandlers() {
               }
               ++i;
               ++state;
-              user = new Buffer(ulen);
+              user = Buffer.alloc(ulen);
               userp = 0;
             break;
             case STATE_UNAME:
@@ -102,7 +102,7 @@ module.exports = function UserPasswordAuthHandlers() {
               }
               ++i;
               ++state;
-              pass = new Buffer(plen);
+              pass = Buffer.alloc(plen);
               passp = 0;
             break;
             case STATE_PASSWD:
@@ -178,7 +178,7 @@ module.exports = function UserPasswordAuthHandlers() {
       }
       stream.on('data', onData);
 
-      var buf = new Buffer(3 + userlen + passlen);
+      var buf = Buffer.alloc(3 + userlen + passlen);
       buf[0] = 0x01;
       buf[1] = userlen;
       buf.write(user, 2, userlen);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,3 +1,4 @@
+'use strict';
 var net = require('net'),
     normalizeConnectArgs = normalizeConnectArgs,
     dns = require('dns'),

--- a/lib/client.js
+++ b/lib/client.js
@@ -89,7 +89,7 @@ Client.prototype._onConnect = function() {
 
   var auths = self._auths,
       alen = auths.length,
-      authsbuf = new Buffer(2 + alen);
+      authsbuf = Buffer.alloc(2 + alen);
   authsbuf[0] = 0x05;
   authsbuf[1] = alen;
   for (var a = 0, p = 2; a < alen; ++a, ++p)
@@ -146,7 +146,7 @@ Client.prototype._sendRequest = function() {
   var addrlen = (iptype === 0
                  ? Buffer.byteLength(self._dstaddr)
                  : (iptype === 4 ? 4 : 16)),
-      reqbuf = new Buffer(6 + (iptype === 0 ? 1 : 0) + addrlen),
+      reqbuf = Buffer.alloc(6 + (iptype === 0 ? 1 : 0) + addrlen),
       p;
   reqbuf[0] = 0x05;
   reqbuf[1] = CMD.CONNECT;

--- a/lib/client.parser.js
+++ b/lib/client.parser.js
@@ -137,9 +137,9 @@ Parser.prototype._onData = function(chunk) {
         var atyp = chunk[i];
         state = STATE_REP_BNDADDR;
         if (atyp === ATYP.IPv4)
-          this._bndaddr = new Buffer(4);
+          this._bndaddr = Buffer.alloc(4);
         else if (atyp === ATYP.IPv6)
-          this._bndaddr = new Buffer(16);
+          this._bndaddr = Buffer.alloc(16);
         else if (atyp === ATYP.NAME)
           state = STATE_REP_BNDADDR_VARLEN;
         else {
@@ -165,7 +165,7 @@ Parser.prototype._onData = function(chunk) {
           state = STATE_REP_BNDPORT;
       break;
       case STATE_REP_BNDADDR_VARLEN:
-        this._bndaddr = new Buffer(chunk[i]);
+        this._bndaddr = Buffer.alloc(chunk[i]);
         state = STATE_REP_BNDADDR;
         ++i;
       break;

--- a/lib/client.parser.js
+++ b/lib/client.parser.js
@@ -1,3 +1,4 @@
+'use strict';
 var inherits = require('util').inherits,
     EventEmitter = require('events').EventEmitter;
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,4 @@
+'use strict';
 exports.CMD = {
   CONNECT: 0x01,
   BIND: 0x02,

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,4 @@
+'use strict';
 var net = require('net'),
     dns = require('dns'),
     util = require('util'),

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,15 +10,15 @@ var Parser = require('./server.parser'),
 var ATYP = require('./constants').ATYP,
     REP = require('./constants').REP;
 
-var BUF_AUTH_NO_ACCEPT = new Buffer([0x05, 0xFF]),
-    BUF_REP_INTR_SUCCESS = new Buffer([0x05,
+var BUF_AUTH_NO_ACCEPT = Buffer.from([0x05, 0xFF]),
+    BUF_REP_INTR_SUCCESS = Buffer.from([0x05,
                                        REP.SUCCESS,
                                        0x00,
                                        0x01,
                                        0x00, 0x00, 0x00, 0x00,
                                        0x00, 0x00]),
-    BUF_REP_DISALLOW = new Buffer([0x05, REP.DISALLOW]),
-    BUF_REP_CMDUNSUPP = new Buffer([0x05, REP.CMDUNSUPP]);
+    BUF_REP_DISALLOW = Buffer.from([0x05, REP.DISALLOW]),
+    BUF_REP_CMDUNSUPP = Buffer.from([0x05, REP.CMDUNSUPP]);
 
 function Server(options, listener) {
   if (!(this instanceof Server))
@@ -86,7 +86,7 @@ Server.prototype._onConnection = function(socket) {
               socket.end();
             }
           });
-          socket.write(new Buffer([0x05, auths[a].METHOD]));
+          socket.write(Buffer.from([0x05, auths[a].METHOD]));
           socket.resume();
           return;
         }
@@ -215,7 +215,7 @@ function proxySocket(socket, req) {
              if (socket.writable) {
               var localbytes = ipbytes(dstSock.localAddress || '127.0.0.1'),
                   len = localbytes.length,
-                  bufrep = new Buffer(6 + len),
+                  bufrep = Buffer.alloc(6 + len),
                   p = 4;
               bufrep[0] = 0x05;
               bufrep[1] = REP.SUCCESS;
@@ -238,7 +238,7 @@ function proxySocket(socket, req) {
 
 function handleProxyError(socket, err) {
   if (socket.writable) {
-    var errbuf = new Buffer([0x05, REP.GENFAIL]);
+    var errbuf = Buffer.from([0x05, REP.GENFAIL]);
     if (err.code) {
       switch (err.code) {
         case 'ENOENT':

--- a/lib/server.parser.js
+++ b/lib/server.parser.js
@@ -1,3 +1,4 @@
+'use strict';
 var inherits = require('util').inherits,
     EventEmitter = require('events').EventEmitter;
 

--- a/lib/server.parser.js
+++ b/lib/server.parser.js
@@ -76,7 +76,7 @@ Parser.prototype._onData = function(chunk) {
         }
         ++i;
         ++state;
-        this._methods = new Buffer(nmethods);
+        this._methods = Buffer.alloc(nmethods);
         this._methodsp = 0;
       break;
       case STATE_METHODS:
@@ -148,9 +148,9 @@ Parser.prototype._onData = function(chunk) {
         var atyp = chunk[i];
         state = STATE_REQ_DSTADDR;
         if (atyp === ATYP.IPv4)
-          this._dstaddr = new Buffer(4);
+          this._dstaddr = Buffer.alloc(4);
         else if (atyp === ATYP.IPv6)
-          this._dstaddr = new Buffer(16);
+          this._dstaddr = Buffer.alloc(16);
         else if (atyp === ATYP.NAME)
           state = STATE_REQ_DSTADDR_VARLEN;
         else {
@@ -176,7 +176,7 @@ Parser.prototype._onData = function(chunk) {
           state = STATE_REQ_DSTPORT;
       break;
       case STATE_REQ_DSTADDR_VARLEN:
-        this._dstaddr = new Buffer(chunk[i]);
+        this._dstaddr = Buffer.alloc(chunk[i]);
         state = STATE_REQ_DSTADDR;
         ++i;
       break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 var net = require('net'),
     Address6 = require('ip-address').Address6;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,11 +16,14 @@ exports.ipbytes = function(str) {
         throw new Error('Error parsing IP: ' + str);
     }
   } else if (type === 6) {
-    var addr = new Address6(str),
+    var addr,
         b = 0,
         group;
-    if (!addr.valid)
-      throw new Error('Error parsing IP: ' + str);
+    try {
+      addr = new Address6(str);
+    } catch (err) {
+      throw new Error('Error parsing IP: ' + str + ': ' + err.message);
+    }
     nums = addr.parsedAddress;
     bytes = new Array(16);
     for (i = 0; i < 8; ++i, b += 2) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.9",
   "author": "Brian White <mscdex@mscdex.net>",
   "dependencies": {
-    "ip-address": "^5.8.8"
+    "ip-address": "^9.0.5"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/test-client-parser.js
+++ b/test/test-client-parser.js
@@ -21,7 +21,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05, 0xFF]));
+      stream.emit('data', Buffer.from([0x05, 0xFF]));
       assert(method === 0xFF,
              makeMsg(what, 'Unexpected method: ' + method));
       next();
@@ -40,8 +40,8 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05]));
-      stream.emit('data', new Buffer([0x09]));
+      stream.emit('data', Buffer.from([0x05]));
+      stream.emit('data', Buffer.from([0x09]));
       assert(method === 0x09,
              makeMsg(what, 'Unexpected method: ' + method));
       next();
@@ -60,7 +60,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x04, 0x09]));
+      stream.emit('data', Buffer.from([0x04, 0x09]));
       assert(errors.length === 1
              && /Incompatible SOCKS protocol version: 4/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));
@@ -81,7 +81,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x00,
                                       0x00,
                                       0x01,
@@ -107,7 +107,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x00,
                                       0x00,
                                       0x04,
@@ -136,7 +136,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x00,
                                       0x00,
                                       0x03,
@@ -164,11 +164,11 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05, 0x00]));
-      stream.emit('data', new Buffer([0x00, 0x03, 0x0A, 0x6E, 0x6F, 0x64, 0x65]));
-      stream.emit('data', new Buffer([0x6A, 0x73, 0x2E, 0x6F, 0x72]));
-      stream.emit('data', new Buffer([0x67, 0x05]));
-      stream.emit('data', new Buffer([0x39]));
+      stream.emit('data', Buffer.from([0x05, 0x00]));
+      stream.emit('data', Buffer.from([0x00, 0x03, 0x0A, 0x6E, 0x6F, 0x64, 0x65]));
+      stream.emit('data', Buffer.from([0x6A, 0x73, 0x2E, 0x6F, 0x72]));
+      stream.emit('data', Buffer.from([0x67, 0x05]));
+      stream.emit('data', Buffer.from([0x39]));
       assert.deepEqual(reply,
                        { bndAddr: 'nodejs.org',
                          bndPort: 1337 },
@@ -190,7 +190,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x05, 0x02]));
+      stream.emit('data', Buffer.from([0x05, 0x02]));
       assert(errors.length === 1
              && /connection not allowed by ruleset/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));
@@ -211,7 +211,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x04, 0x02]));
+      stream.emit('data', Buffer.from([0x04, 0x02]));
       assert(errors.length === 1
              && /Incompatible SOCKS protocol version: 4/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));
@@ -232,11 +232,11 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x05, 0x00]));
-      stream.emit('data', new Buffer([0x00, 0xFF, 0x0A, 0x6E, 0x6F, 0x64, 0x65]));
-      stream.emit('data', new Buffer([0x6A, 0x73, 0x2E, 0x6F, 0x72]));
-      stream.emit('data', new Buffer([0x67, 0x05]));
-      stream.emit('data', new Buffer([0x39]));
+      stream.emit('data', Buffer.from([0x05, 0x00]));
+      stream.emit('data', Buffer.from([0x00, 0xFF, 0x0A, 0x6E, 0x6F, 0x64, 0x65]));
+      stream.emit('data', Buffer.from([0x6A, 0x73, 0x2E, 0x6F, 0x72]));
+      stream.emit('data', Buffer.from([0x67, 0x05]));
+      stream.emit('data', Buffer.from([0x39]));
       assert(errors.length === 1
              && /Invalid request address type: 255/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));

--- a/test/test-client-parser.js
+++ b/test/test-client-parser.js
@@ -1,3 +1,4 @@
+'use strict';
 var Parser = require('../lib/client.parser');
 
 var EventEmitter = require('events').EventEmitter,

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -1,3 +1,4 @@
+'use strict';
 var auth = require('../index').auth,
     createServer = require('../index').createServer,
     connect = require('../index').connect;

--- a/test/test-server-parser.js
+++ b/test/test-server-parser.js
@@ -1,3 +1,4 @@
+'use strict';
 var Parser = require('../lib/server.parser');
 
 var EventEmitter = require('events').EventEmitter,

--- a/test/test-server-parser.js
+++ b/test/test-server-parser.js
@@ -22,9 +22,9 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05, 0x01, 0x00]));
+      stream.emit('data', Buffer.from([0x05, 0x01, 0x00]));
       assert.deepEqual(methods,
-                       new Buffer([0x00]),
+                       Buffer.from([0x00]),
                        makeMsg(what, 'Unexpected methods: ' + inspect(methods)));
       next();
     },
@@ -42,11 +42,11 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05]));
-      stream.emit('data', new Buffer([0x01]));
-      stream.emit('data', new Buffer([0x00]));
+      stream.emit('data', Buffer.from([0x05]));
+      stream.emit('data', Buffer.from([0x01]));
+      stream.emit('data', Buffer.from([0x00]));
       assert.deepEqual(methods,
-                       new Buffer([0x00]),
+                       Buffer.from([0x00]),
                        makeMsg(what, 'Unexpected methods: ' + inspect(methods)));
       next();
     },
@@ -64,7 +64,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x04, 0x01, 0x00]));
+      stream.emit('data', Buffer.from([0x04, 0x01, 0x00]));
       assert(errors.length === 1
              && /Incompatible SOCKS protocol version: 4/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));
@@ -84,7 +84,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x05, 0x00]));
+      stream.emit('data', Buffer.from([0x05, 0x00]));
       assert(errors.length === 1
              && /empty methods list/i.test(errors[0].message),
              makeMsg(what, 'Error(s) mismatch'));
@@ -105,7 +105,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x01,
                                       0x00,
                                       0x01,
@@ -135,7 +135,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x02,
                                       0x00,
                                       0x01,
@@ -165,7 +165,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x03,
                                       0x00,
                                       0x01,
@@ -195,7 +195,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x01,
                                       0x00,
                                       0x04,
@@ -228,7 +228,7 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x01,
                                       0x00,
                                       0x03,
@@ -259,14 +259,14 @@ var tests = [
       }).on('error', function(err) {
         assert(false, makeMsg(what, 'Unexpected error: ' + err));
       });
-      stream.emit('data', new Buffer([0x05]));
-      stream.emit('data', new Buffer([0x01, 0x00, 0x03]));
-      stream.emit('data', new Buffer([0x0A]));
-      stream.emit('data', new Buffer([0x6E, 0x6F, 0x64, 0x65, 0x6A, 0x73]));
-      stream.emit('data', new Buffer([0x2E, 0x6F, 0x72]));
-      stream.emit('data', new Buffer([0x67]));
-      stream.emit('data', new Buffer([0x05]));
-      stream.emit('data', new Buffer([0x39]));
+      stream.emit('data', Buffer.from([0x05]));
+      stream.emit('data', Buffer.from([0x01, 0x00, 0x03]));
+      stream.emit('data', Buffer.from([0x0A]));
+      stream.emit('data', Buffer.from([0x6E, 0x6F, 0x64, 0x65, 0x6A, 0x73]));
+      stream.emit('data', Buffer.from([0x2E, 0x6F, 0x72]));
+      stream.emit('data', Buffer.from([0x67]));
+      stream.emit('data', Buffer.from([0x05]));
+      stream.emit('data', Buffer.from([0x39]));
       assert.deepEqual(request,
                        { cmd: 'connect',
                          srcAddr: undefined,
@@ -291,7 +291,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x04,
+      stream.emit('data', Buffer.from([0x04,
                                       0x01,
                                       0x00,
                                       0x01,
@@ -317,7 +317,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0xFE,
                                       0x00,
                                       0x01,
@@ -343,7 +343,7 @@ var tests = [
       }).on('error', function(err) {
         errors.push(err);
       });
-      stream.emit('data', new Buffer([0x05,
+      stream.emit('data', Buffer.from([0x05,
                                       0x01,
                                       0x00,
                                       0xFF,

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,3 +1,4 @@
+'use strict';
 var auth = require('../index').auth,
     createServer = require('../index').createServer;
 const net = require('net');

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,7 +1,9 @@
 var auth = require('../index').auth,
     createServer = require('../index').createServer;
+const net = require('net');
 
 var Socket = require('net').Socket,
+    isIPv6 = require('net').isIPv6,
     cpexec = require('child_process').execFile,
     http = require('http'),
     path = require('path'),
@@ -14,6 +16,10 @@ var t = -1,
     httpPort;
 
 var HTTP_RESPONSE = 'hello from the node.js http server!';
+
+function wrapIfIPv6(addr) {
+  return isIPv6(addr) ? `[${addr}]` : addr;
+}
 
 var tests = [
   { run: function() {
@@ -39,8 +45,8 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
-                    'http://' + httpAddr + ':' + httpPort];
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err, stdout, stderr) {
           server.close();
           assert(!err, makeMsg(what, 'Unexpected client error: '
@@ -80,10 +86,10 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
                     '-U',
                     'nodejs:rules',
-                    'http://' + httpAddr + ':' + httpPort];
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err, stdout, stderr) {
           server.close();
           assert(!err, makeMsg(what, 'Unexpected client error: '
@@ -112,10 +118,10 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
                     '-U',
                     'php:rules',
-                    'http://' + httpAddr + ':' + httpPort];
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err) {
           server.close();
           assert(err, makeMsg(what, 'Expected client error'));
@@ -141,8 +147,8 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
-                    'http://' + httpAddr + ':' + httpPort];
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err) {
           server.close();
           assert(err, makeMsg(what, 'Expected client error'));
@@ -167,8 +173,8 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
-                    'http://' + httpAddr + ':' + httpPort];
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err) {
           server.close();
           assert(err, makeMsg(what, 'Expected client error'));
@@ -204,8 +210,8 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
-                    'http://' + httpAddr + ':' + httpPort];
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err, stdout, stderr) {
           server.close();
           assert(!err, makeMsg(what, 'Unexpected client error: '
@@ -244,8 +250,8 @@ var tests = [
 
       server.listen(0, 'localhost', function() {
         var args = ['--socks5',
-                    this.address().address + ':' + this.address().port,
-                    'http://' + httpAddr + ':' + httpPort];
+                    wrapIfIPv6(this.address().address) + ':' + this.address().port,
+                    'http://' + wrapIfIPv6(httpAddr) + ':' + httpPort];
         cpexec('curl', args, function(err, stdout, stderr) {
           server.close();
           assert(err, makeMsg(what, 'Expected client error'));

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -292,7 +292,7 @@ var tests = [
                    makeMsg(what,
                            'Timeout while waiting for bad client socket end'));
           }, 100);
-          clientSock.write(new Buffer([0x04, 0x01, 0x00]));
+          clientSock.write(Buffer.from([0x04, 0x01, 0x00]));
         }).connect(this.address().port, 'localhost');
       });
     },

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+'use strict';
 var spawn = require('child_process').spawn,
     join = require('path').join;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,47 +2,20 @@
 # yarn lockfile v1
 
 
-ip-address@^5.8.8:
-  version "5.8.8"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.8.8.tgz#5fd1f8f7465249fb7d2b3c1eec7b41d29d1f1b76"
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
   dependencies:
-    jsbn "0.1.0"
-    lodash.find "^4.6.0"
-    lodash.max "^4.0.1"
-    lodash.merge "^4.6.0"
-    lodash.padstart "^4.6.1"
-    lodash.repeat "^4.1.0"
-    sprintf-js "^1.0.3"
-    util-deprecate "^1.0.2"
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
 
-jsbn@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-
-lodash.max@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.max/-/lodash.max-4.0.1.tgz#8735566c618b35a9f760520b487ae79658af136a"
-
-lodash.merge@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
-
-lodash.padstart@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
-
-lodash.repeat@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.1.0.tgz#fc7de8131d8c8ac07e4b49f74ffe829d1f2bec44"
-
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
-util-deprecate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==


### PR DESCRIPTION
Just some general modifications to make this code a bit more modern, improve testing, bump dependencies, and address deprecation warnings.

---

##### chore: make tests pass when localhost resolves to ::1


##### fix: replace usage of `new Buffer()`

Fixes: https://github.com/heroku/socksv5/issues/3

##### chore: add `'use strict'` directives


##### chore(deps): update ip-address to 9.x


##### chore: add github workflows
